### PR TITLE
Refactor userDetailsService to use PasswordEncoder for encoding passwords

### DIFF
--- a/section3/src/main/java/com/eazybytes/springsecsection3/configs/ProjectSecurityConfig.java
+++ b/section3/src/main/java/com/eazybytes/springsecsection3/configs/ProjectSecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -34,16 +36,21 @@ public class ProjectSecurityConfig {
     }
 
     @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
     public UserDetailsService userDetailsService() {
         UserDetails user =
                 User.withUsername("user")
-                        .password("{noop}1234")
+                        .password(passwordEncoder().encode("1234"))
                         .authorities("read")
                         .build();
 
         UserDetails admin =
                 User.withUsername("admin")
-                        .password("{noop}1234")
+                        .password(passwordEncoder().encode("1234"))
                         .authorities("admin")
                         .build();
 


### PR DESCRIPTION
- Replaced {noop} with passwordEncoder().encode(...) for user and admin credentials
- Introduced PasswordEncoder bean using PasswordEncoderFactories.createDelegatingPasswordEncoder()